### PR TITLE
Order annotation.csv according to sample order so it matches UI

### DIFF
--- a/ada_tools/src/ada_tools/setup_discount.py
+++ b/ada_tools/src/ada_tools/setup_discount.py
@@ -92,12 +92,11 @@ def main(input, pre_images, post_images, outdir, out_csv):
     pre_bounds_and_urls = get_image_dir_contents(pre_images)
     post_bounds_and_urls = get_image_dir_contents(post_images)
 
-
     for i, tile_id in enumerate(tile_ids):
         df = gdf.loc[gdf["TILE_ID"] == tile_id]
         tile_bounds = get_tile_bounds(tile_id)
         df_geojson = json.loads(df.to_json())
-        df_geojson['indexes'] = tile_to_sample_map[tile_id]
+        df_geojson['indexes'] = tile_to_sample_map.get(tile_id, [])
         df_geojson['tile_bbox'] = ','.join([str(c) for c in tile_bounds])
         df_geojson['annotated'] = False
         df_geojson['detector_count'] = detector_counts[i]

--- a/ada_tools/src/ada_tools/setup_discount.py
+++ b/ada_tools/src/ada_tools/setup_discount.py
@@ -82,7 +82,7 @@ def main(input, pre_images, post_images, outdir, out_csv):
     sample_order = np.arange(len(samples), dtype=int)
     sample_tracking_df = pd.DataFrame({tile_id_key: samples, "ordering": sample_order})
     display_order = sample_tracking_df.groupby(tile_id_key)["ordering"].min().reset_index()
-    tiles_df = pd.merge(tiles_df, display_order, on=tile_id_key).sort_values(by="ordering")
+    tiles_df = pd.merge(tiles_df, display_order, how="left", on=tile_id_key).sort_values(by="ordering")
     tiles_df.to_csv(out_csv, index=False, columns=[tile_id_key, "detector_count", "true_count", "Annotator"])
 
     # Collect sample indices to be written to each tile's geoJSON file

--- a/ada_tools/src/ada_tools/setup_discount.py
+++ b/ada_tools/src/ada_tools/setup_discount.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 import json
 import os
 from pathlib import Path

--- a/ada_tools/src/ada_tools/setup_discount.py
+++ b/ada_tools/src/ada_tools/setup_discount.py
@@ -50,6 +50,7 @@ def get_image_dir_contents(image_dir):
 
     return image_bounds_and_urls
 
+
 @click.command()
 @click.option('--input', help='input predictions')
 @click.option('--pre-images', help='directory containing pre-disaster images')
@@ -62,28 +63,36 @@ def main(input, pre_images, post_images, outdir, out_csv):
     gdf = gdf[gdf["damage"] >= 1.0]
 
     os.makedirs(outdir, exist_ok=True)
+
+    tile_id_key = "TILE_ID"
     
-    tiles_df = gdf.groupby('TILE_ID')['damage'].count().reset_index().rename(columns={'damage': 'detector_count'})
+    tiles_df = gdf.groupby(tile_id_key)['damage'].count().reset_index().rename(columns={'damage': 'detector_count'})
     tiles_df.loc[:, ['true_count', 'Annotator']] = ''
     detector_counts = list(tiles_df['detector_count'])
     if min(detector_counts) == 0:
         detector_counts = [c + max(max(detector_counts)*EPS, 1) for c in detector_counts]
 
     tiles_df['detector_count'] = detector_counts
-    tiles_df.to_csv(out_csv, index=False)
 
-    tile_ids = list(tiles_df['TILE_ID'])
+    # Performs DISCount sampling
+    tile_ids = list(tiles_df[tile_id_key])
     prob_dist = np.array(detector_counts) / np.sum(detector_counts)
     samples = list(np.random.choice(tile_ids, 2 * len(tile_ids), p=prob_dist, replace=True))
 
-    tile_to_sample_map = defaultdict(list)
+    # Order annotation tracking CSV by each tile's first sample index
+    sample_order = np.arange(len(samples), dtype=int)
+    sample_tracking_df = pd.DataFrame({tile_id_key: samples, "ordering": sample_order})
+    display_order = sample_tracking_df.groupby(tile_id_key)["ordering"].min().reset_index()
+    tiles_df = pd.merge(tiles_df, display_order, on=tile_id_key).sort_values(by="ordering")
+    tiles_df.to_csv(out_csv, index=False, columns=[tile_id_key, "detector_count", "true_count", "Annotator"])
 
+    # Collect sample indices to be written to each tile's geoJSON file
+    tile_to_sample_map = sample_tracking_df.groupby(tile_id_key)["ordering"].apply(list).to_dict()
+ 
     # add event bounds
     pre_bounds_and_urls = get_image_dir_contents(pre_images)
     post_bounds_and_urls = get_image_dir_contents(post_images)
 
-    for i, sample in enumerate(samples):
-        tile_to_sample_map[sample] += [i]
 
     for i, tile_id in enumerate(tile_ids):
         df = gdf.loc[gdf["TILE_ID"] == tile_id]


### PR DESCRIPTION
This fixes https://github.com/UMassCDS/RedCross2022/issues/63 by ordering the annotation.csv files by the tile id's first DISCount sample index. 

I re-ran the final DISCount step with the Typhoon Mangkhut data and updated testing data shared at https://drive.google.com/file/d/1Pg0fh0NQP2E-d38LK3CMMYwT819Vc34C/view?usp=sharing 